### PR TITLE
feat: Updated bcryptCost to minCost

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -57,7 +57,7 @@ const (
 	ItemsPerPage        = 48
 	TransactionsPerPage = 10
 
-	BcryptCost = 10
+	BcryptCost = 4
 )
 
 var (


### PR DESCRIPTION
## WHY
pprofを見るとログイン周りがボトルネックになっていることがわかり、ここを少しでも軽くしたかったため
## WHAT
- BcryptCostをmincost(4)に変更
- https://github.com/Ichigo-dev/isucon9/issues/2#issuecomment-909252847